### PR TITLE
fix: update default `cancel_on_strings` value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   cancel_on_strings:
     description: Cancel the action when comment contains these words (comma separated list)
     required: false
-    default: "Deployment in progress,Preview: Failed,In Progress,🔄 Building"
+    default: "Deployment in progress,Preview: Failed,In Progress,🔄 Building,❌ Failed"
   GITHUB_TOKEN:
     description: >-
       GitHub actions token to cancel the action in case preview URL could not be

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   cancel_on_strings:
     description: Cancel the action when comment contains these words (comma separated list)
     required: false
-    default: "Deployment in progress,Preview: Failed,In Progress"
+    default: "Deployment in progress,Preview: Failed,In Progress,🔄 Building"
   GITHUB_TOKEN:
     description: >-
       GitHub actions token to cancel the action in case preview URL could not be


### PR DESCRIPTION
With the latest comment formatting from Vercel, the action is being executed when the comment is edited into the following "🔄 Building" status:

<img width="923" alt="Screenshot 2023-05-04 at 04 15 37" src="https://user-images.githubusercontent.com/5795227/236096882-36232bae-07c0-4297-ac2e-a7d010820a16.png">